### PR TITLE
#1 stroke를 path 위에 그리도록 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -216,15 +216,6 @@ export default function App() {
           >
             {pathList.map((pathData, index) => (
               <>
-                <path
-                  key={`path-${index}`}
-                  d={pathData.path}
-                  fill="none"
-                  stroke={pathData.lineColor}
-                  strokeWidth={pathData.lineWidth}
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
                 {pathData.strokeWidth > 0 && (
                   <path
                     key={`stroke-${index}`}
@@ -234,9 +225,17 @@ export default function App() {
                     strokeWidth={pathData.lineWidth + pathData.strokeWidth * 2}
                     strokeLinecap="round"
                     strokeLinejoin="round"
-                    style={{ mixBlendMode: "multiply" }}
                   />
                 )}
+                <path
+                  key={`path-${index}`}
+                  d={pathData.path}
+                  fill="none"
+                  stroke={pathData.lineColor}
+                  strokeWidth={pathData.lineWidth}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
               </>
             ))}
             {currentPath && (
@@ -249,7 +248,6 @@ export default function App() {
                     strokeWidth={lineWidth + strokeWidth * 2}
                     strokeLinecap="round"
                     strokeLinejoin="round"
-                    style={{ mixBlendMode: "multiply" }}
                   />
                 )}
                 <path


### PR DESCRIPTION
## Fixed
- `mix-blend-mode: "multiply"` 속성 제거
- stroke를 path보다 먼저 렌더링하도록 수정
- path 머지 로직은 추후 추가 (색상이 잘못 노출되는 문제 우선순위가 더 우선)